### PR TITLE
Treat exception responses as valid frames

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -123,7 +123,7 @@ class ModbusTransactionManager(object):
             return False
 
         mbap = self.client.framer.decode_data(response)
-        if mbap.get('unit') != request.unit_id or mbap.get('fcode') != request.function_code:
+        if mbap.get('unit') != request.unit_id or mbap.get('fcode') & 0x7F != request.function_code:
             return False
 
         if 'length' in mbap and exp_resp_len:


### PR DESCRIPTION
When response is validated and the response is an exception, the function code is FC + 0x80 which the current logic treats as an invalid function code.